### PR TITLE
linux-firmware-gslx680: move fw to silead subfolder

### DIFF
--- a/recipes-kernel/linux-firmware/linux-firmware-gslx680_1.0.bb
+++ b/recipes-kernel/linux-firmware/linux-firmware-gslx680_1.0.bb
@@ -22,8 +22,8 @@ inherit allarch update-alternatives
 CLEANBROKEN = "1"
 
 do_install() {
-    mkdir -p ${D}/lib/firmware/
-    install -m 0644 ${WORKDIR}/gsl1680.fw ${D}/lib/firmware/
+    mkdir -p ${D}/lib/firmware/silead
+    install -m 0644 ${WORKDIR}/gsl1680.fw ${D}/lib/firmware/silead/
 }
 
 FILES_${PN} += "/lib/firmware/*"


### PR DESCRIPTION
Move firmware file to silead subfolder, as recent kernel require since:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/drivers/input/touchscreen/silead.c?id=4af2ff91ec3f42b538a65cf12df5f9faf6aaa914

Signed-off-by: Diego Rondini <diego.rondini@kynetics.com>