### PR TITLE
networkmanager: fix build error when /etc/NetworkManager does not exist

### DIFF
--- a/dynamic-layers/networking-layer/recipes-connectivity/networkmanager/networkmanager_%.bbappend
+++ b/dynamic-layers/networking-layer/recipes-connectivity/networkmanager/networkmanager_%.bbappend
@@ -5,8 +5,6 @@ SRC_URI:append = " \
 "
 
 do_install:append() {
-
-	install -m 755 ${WORKDIR}/NetworkManager.conf ${D}/etc/NetworkManager
-
+	install -d ${D}${sysconfdir}/NetworkManager/
+	install -m 0755 ${WORKDIR}/NetworkManager.conf ${D}${sysconfdir}/NetworkManager/NetworkManager.conf
 }
-


### PR DESCRIPTION
If the ${D}/etc/NetworkManager/ directory does not exist already, the
do_install_append here may erroneously copy NetworkManager.conf into
the file /etc/NetworkManager. This may cause downstream bbappends to
fail because /etc/NetworkManager is now file, instead of a directory.

Let's prevent this by creating the directory first.

Signed-off-by: Eric Wang <eric@rwx.one>