### PR TITLE
nitrogen8mp: use weak assignment with WKS_FILE

### DIFF
--- a/conf/machine/nitrogen8mp.conf
+++ b/conf/machine/nitrogen8mp.conf
@@ -68,7 +68,7 @@ IMAGE_BOOT_FILES:append = " \
 "
 
 # wic support
-WKS_FILE = "sdimage-bootpart.wks"
+WKS_FILE ?= "sdimage-bootpart.wks"
 WKS_FILE_DEPENDS += "u-boot-script-boundary"
 
 OPTEE_BIN_EXT = "8mp"


### PR DESCRIPTION
This allows users to use a custom wic kickstart file when targeting `nitrogen8mp` machine