### PR TITLE
Update firmware-ele-imx_%.bbappend

### DIFF
--- a/recipes-bsp/firmware-imx/firmware-ele-imx_%.bbappend
+++ b/recipes-bsp/firmware-imx/firmware-ele-imx_%.bbappend
@@ -4,9 +4,6 @@ SRC_URI:append:mx93-nxp-bsp = " \
 	file://mx93a1-ahab-container.img \
 "
 
-SRC_URI[md5sum] = "777d36d1bc39522d975165686935fc33"
-SRC_URI[sha256sum] = "5d50d5c7a9d1bcc225ca8dc62a582074d88e3adb6c5eea2d1614aa18c61d6ff9"
-
 do_install:prepend:mx93-nxp-bsp () {
     cp ${WORKDIR}/mx93a1-ahab-container.img ${S}/
 }


### PR DESCRIPTION
Removed hash overriding the ones from the original recipe.

Not clear with those where redefined here, but currently outdated. If required, the current hashes are :
SRC_URI[md5sum] = "1f446ef80aeac6d17ce78bfd8f2950c0"
SRC_URI[sha256sum] = "8791109824767346237e53ac2c712824e54608e2092859161e6bb3e5385a7595"

