### PR TITLE
ezurio-core-image: add missing firmwared package

### DIFF
--- a/recipes-boundary/images/ezurio-core-image-base.bb
+++ b/recipes-boundary/images/ezurio-core-image-base.bb
@@ -22,6 +22,7 @@ CORE_IMAGE_EXTRA_INSTALL += " \
     ethtool \
     evtest \
     fw-env-rules \
+    firmwared \
     i2c-tools \
     iperf3 \
     iproute2 \


### PR DESCRIPTION
The `ezurio-core-image-base.bb` recipe failed to correctly load firmware for WiFi/BT module.  This is resolved by adding the `firmwared` package to the image.

Note: `boundary-image-full.bb` recipe works because it requires `imx-image-multimedia.bb` which has `firmwared`.