### PR TITLE
nitrogen93: add nvc-rpmsg device tree blob

### DIFF
--- a/conf/machine/nitrogen93.conf
+++ b/conf/machine/nitrogen93.conf
@@ -21,6 +21,7 @@ KERNEL_DEVICETREE = "freescale/imx93-nitrogen-smarc.dtb \
 	freescale/imx93-nitrogen-smarc-spi-slave.dtb \
 	freescale/imx93-nitrogen-smarc-tevs.dtb \
 	freescale/imx93-nvc.dtb \
+	freescale/imx93-nvc-rpmsg.dtb \
 "
 KERNEL_IMAGETYPE = "Image"
 RRECOMMENDS:${KERNEL_PACKAGE_NAME}-base = ""

--- a/recipes-kernel/linux/linux-boundary_6.6.bb
+++ b/recipes-kernel/linux/linux-boundary_6.6.bb
@@ -15,7 +15,7 @@ SRC_URI = "git://github.com/boundarydevices/linux.git;branch=${SRCBRANCH};protoc
 
 LOCALVERSION = "+yocto"
 SRCBRANCH = "ezurio-lf-6.6.y"
-SRCREV = "b6c9a6c2749146cb7efdf36a0929032d33772ec7"
+SRCREV = "3406c561f03c2d66e60f7af61637d2299368023a"
 DEPENDS += "lzop-native bc-native"
 COMPATIBLE_MACHINE = "(nitrogen8m|nitrogen8mm|nitrogen8mn|nitrogen8mp|nitrogen8ulp|nitrogen93|nitrogen95|porpoise)"
 


### PR DESCRIPTION
Adds imx93-nvc-rpmsg.dtb to nitrogen93 machine conf.

Please merge this **after** merging https://github.com/boundarydevices/linux/pull/75 so I can grab the commit and update the `SRCREV` here to match appropriately. (Since squash/merge of PRs generates a new commit hash)