### PR TITLE
boundary-image-full: Fix hash mismatch in onnxruntime build

### DIFF
--- a/recipes-libraries/onnxruntime/onnxruntime/1001-cmake-deps.txt-fix-eigen-hash.patch
+++ b/recipes-libraries/onnxruntime/onnxruntime/1001-cmake-deps.txt-fix-eigen-hash.patch
@@ -1,0 +1,11 @@
+--- a/cmake/deps.txt	2025-06-20 09:17:54.646554657 -0400
++++ b/cmake/deps.txt	2025-06-20 09:45:30.637546524 -0400
+@@ -21,7 +21,7 @@
+ # it contains changes on top of 3.4.0 which are required to fix build issues.
+ # Until the 3.4.1 release this is the best option we have.
+ # Issue link: https://gitlab.com/libeigen/eigen/-/issues/2744
+-eigen;https://gitlab.com/libeigen/eigen/-/archive/e7248b26a1ed53fa030c5c459f7ea095dfd276ac/eigen-e7248b26a1ed53fa030c5c459f7ea095dfd276ac.zip;be8be39fdbc6e60e94fa7870b280707069b5b81a
++eigen;https://gitlab.com/libeigen/eigen/-/archive/e7248b26a1ed53fa030c5c459f7ea095dfd276ac/eigen-e7248b26a1ed53fa030c5c459f7ea095dfd276ac.zip;32b145f525a8308d7ab1c09388b2e288312d8eba
+ flatbuffers;https://github.com/google/flatbuffers/archive/refs/tags/v1.12.0.zip;ba0a75fd12dbef8f6557a74e611b7a3d0c5fe7bf
+ fp16;https://github.com/Maratyszcza/FP16/archive/0a92994d729ff76a58f692d3028ca1b64b145d91.zip;b985f6985a05a1c03ff1bb71190f66d8f98a1494
+ fxdiv;https://github.com/Maratyszcza/FXdiv/archive/63058eff77e11aa15bf531df5dd34395ec3017c8.zip;a5658f4036402dbca7cebee32be57fb8149811e1

--- a/recipes-libraries/onnxruntime/onnxruntime_1.17.1.bbappend
+++ b/recipes-libraries/onnxruntime/onnxruntime_1.17.1.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI:append = "\
+        file://1001-cmake-deps.txt-fix-eigen-hash.patch \
+        "


### PR DESCRIPTION
I ran across a build error for the `onnxruntime` package while building the `boundary-image-full` image against the `nitrogen8mp`:

<details><summary>Error log</summary>
<p>

```
...
| DEBUG: Executing shell function do_configure
| -- The C compiler identification is GNU 13.3.0
| -- The CXX compiler identification is GNU 13.3.0
| -- The ASM compiler identification is GNU
| -- Found assembler: /home/chris/dev/scarthgap/build/tmp/work/armv8a-poky-linux/onnxruntime/1.17.1/recipe-sysroot-native/usr/bin/aarch64-poky-linux/aarch64-poky-linux-gcc
| -- Detecting C compiler ABI info
| -- Detecting C compiler ABI info - done
| -- Check for working C compiler: /home/chris/dev/scarthgap/build/tmp/work/armv8a-poky-linux/onnxruntime/1.17.1/recipe-sysroot-native/usr/bin/aarch64-poky-linux/aarch64-poky-linux-gcc - skipped
| -- Detecting C compile features
| -- Detecting C compile features - done
| -- Detecting CXX compiler ABI info
| -- Detecting CXX compiler ABI info - done
| -- Check for working CXX compiler: /home/chris/dev/scarthgap/build/tmp/work/armv8a-poky-linux/onnxruntime/1.17.1/recipe-sysroot-native/usr/bin/aarch64-poky-linux/aarch64-poky-linux-g++ - skipped
| -- Detecting CXX compile features
| -- Detecting CXX compile features - done
| -- Performing Test HAS_NOERROR
| -- Performing Test HAS_NOERROR - Success
| -- Performing Test COMPILER_SUPPORT_MF16C
| -- Performing Test COMPILER_SUPPORT_MF16C - Failed
| F16C instruction set is not supported.
| -- Performing Test COMPILER_SUPPORT_FMA
| -- Performing Test COMPILER_SUPPORT_FMA - Failed
| FMA instruction set is not supported.
| -- Performing Test COMPILER_SUPPORT_AVX
| -- Performing Test COMPILER_SUPPORT_AVX - Failed
| AVX instruction set is not supported.
| One or more AVX/F16C instruction flags are not supported.
| Building ONNX Runtime for aarch64 CPU ARCH
| -- Performing Test onnxruntime_HAVE_BUILTIN_ATOMICS
| -- Performing Test onnxruntime_HAVE_BUILTIN_ATOMICS - Success
| -- Performing Test CMAKE_HAVE_LIBC_PTHREAD
| -- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
| -- Found Threads: TRUE
| -- Performing Test Iconv_IS_BUILT_IN
| -- Performing Test Iconv_IS_BUILT_IN - Success
| -- Found Iconv: built in to C library
| -- Found Patch: /home/chris/dev/scarthgap/build/tmp/work/armv8a-poky-linux/onnxruntime/1.17.1/recipe-sysroot-native/usr/bin/patch
| Patch found: /home/chris/dev/scarthgap/build/tmp/work/armv8a-poky-linux/onnxruntime/1.17.1/recipe-sysroot-native/usr/bin/patch
| Doing crosscompiling
| -- Found Python: /home/chris/dev/scarthgap/build/tmp/work/armv8a-poky-linux/onnxruntime/1.17.1/recipe-sysroot-native/usr/bin/python3-native/python3 (found suitable version "3.12.6", minimum required is "3.8") found components: Interpreter Development.Module NumPy
| Loading Dependencies URLs ...
| Loading Dependencies ...
| -- Performing Test ABSL_INTERNAL_AT_LEAST_CXX17
| -- Performing Test ABSL_INTERNAL_AT_LEAST_CXX17 - Success
| -- Performing Test ABSL_INTERNAL_AT_LEAST_CXX20
| -- Performing Test ABSL_INTERNAL_AT_LEAST_CXX20 - Failed
| -- Abseil source dir:/home/chris/dev/scarthgap/build/tmp/work/armv8a-poky-linux/onnxruntime/1.17.1/build/_deps/abseil_cpp-src
| CMAKE_HOST_SYSTEM_NAME: Linux
| Use prebuilt protoc
| # date: USE_SYSTEM_TZ_DB ON
| # date: MANUAL_TZ_DB OFF
| # date: USE_TZ_DB_IN_DOT OFF
| # date: BUILD_SHARED_LIBS OFF
| # date: ENABLE_DATE_TESTING OFF
| # date: DISABLE_STRING_VIEW OFF
| --
| -- 3.21.12.0
| -- Performing Test protobuf_HAVE_LD_VERSION_SCRIPT
| -- Performing Test protobuf_HAVE_LD_VERSION_SCRIPT - Success
| -- Found ZLIB: /home/chris/dev/scarthgap/build/tmp/work/armv8a-poky-linux/onnxruntime/1.17.1/recipe-sysroot/usr/lib/libz.so (found version "1.3.1")
| -- Performing Test protobuf_HAVE_BUILTIN_ATOMICS
| -- Performing Test protobuf_HAVE_BUILTIN_ATOMICS - Success
| -- Using the single-header code from /home/chris/dev/scarthgap/build/tmp/work/armv8a-poky-linux/onnxruntime/1.17.1/build/_deps/nlohmann_json-src/single_include/
| -- Looking for strtof_l
| -- Looking for strtof_l - found
| -- Looking for strtoull_l
| -- Looking for strtoull_l - found
| -- Using toolchain file: /home/chris/dev/scarthgap/build/tmp/work/armv8a-poky-linux/onnxruntime/1.17.1/toolchain.cmake.
| fatal: not a git repository (or any of the parent directories): .git
| [ 11%] Creating directories for 'eigen-populate'
| [ 22%] Performing download step (download, verify and extract) for 'eigen-populate'
| -- Downloading...
|    dst='/home/chris/dev/scarthgap/build/tmp/work/armv8a-poky-linux/onnxruntime/1.17.1/build/_deps/eigen-subbuild/eigen-populate-prefix/src/eigen-e7248b26a1ed53fa030c5c459f7ea095dfd276ac.zip'
|    timeout='none'
|    inactivity timeout='none'
| -- Using src='https://gitlab.com/libeigen/eigen/-/archive/e7248b26a1ed53fa030c5c459f7ea095dfd276ac/eigen-e7248b26a1ed53fa030c5c459f7ea095dfd276ac.zip'
| -- verifying file...
|        file='/home/chris/dev/scarthgap/build/tmp/work/armv8a-poky-linux/onnxruntime/1.17.1/build/_deps/eigen-subbuild/eigen-populate-prefix/src/eigen-e7248b26a1ed53fa030c5c459f7ea095dfd276ac.zip'
| -- SHA1 hash of
|     /home/chris/dev/scarthgap/build/tmp/work/armv8a-poky-linux/onnxruntime/1.17.1/build/_deps/eigen-subbuild/eigen-populate-prefix/src/eigen-e7248b26a1ed53fa030c5c459f7ea095dfd276ac.zip
|   does not match expected value
|     expected: 'be8be39fdbc6e60e94fa7870b280707069b5b81a'
|       actual: '32b145f525a8308d7ab1c09388b2e288312d8eba'
| -- Hash mismatch, removing...
| -- Using src='https://gitlab.com/libeigen/eigen/-/archive/e7248b26a1ed53fa030c5c459f7ea095dfd276ac/eigen-e7248b26a1ed53fa030c5c459f7ea095dfd276ac.zip'
| -- verifying file...
|        file='/home/chris/dev/scarthgap/build/tmp/work/armv8a-poky-linux/onnxruntime/1.17.1/build/_deps/eigen-subbuild/eigen-populate-prefix/src/eigen-e7248b26a1ed53fa030c5c459f7ea095dfd276ac.zip'
| -- SHA1 hash of
|     /home/chris/dev/scarthgap/build/tmp/work/armv8a-poky-linux/onnxruntime/1.17.1/build/_deps/eigen-subbuild/eigen-populate-prefix/src/eigen-e7248b26a1ed53fa030c5c459f7ea095dfd276ac.zip
|   does not match expected value
|     expected: 'be8be39fdbc6e60e94fa7870b280707069b5b81a'
|       actual: '32b145f525a8308d7ab1c09388b2e288312d8eba'
| -- Hash mismatch, removing...
| -- Using src='https://gitlab.com/libeigen/eigen/-/archive/e7248b26a1ed53fa030c5c459f7ea095dfd276ac/eigen-e7248b26a1ed53fa030c5c459f7ea095dfd276ac.zip'
| -- verifying file...
|        file='/home/chris/dev/scarthgap/build/tmp/work/armv8a-poky-linux/onnxruntime/1.17.1/build/_deps/eigen-subbuild/eigen-populate-prefix/src/eigen-e7248b26a1ed53fa030c5c459f7ea095dfd276ac.zip'
| -- SHA1 hash of
|     /home/chris/dev/scarthgap/build/tmp/work/armv8a-poky-linux/onnxruntime/1.17.1/build/_deps/eigen-subbuild/eigen-populate-prefix/src/eigen-e7248b26a1ed53fa030c5c459f7ea095dfd276ac.zip
|   does not match expected value
|     expected: 'be8be39fdbc6e60e94fa7870b280707069b5b81a'
|       actual: '32b145f525a8308d7ab1c09388b2e288312d8eba'
| -- Hash mismatch, removing...
| -- Using src='https://gitlab.com/libeigen/eigen/-/archive/e7248b26a1ed53fa030c5c459f7ea095dfd276ac/eigen-e7248b26a1ed53fa030c5c459f7ea095dfd276ac.zip'
| -- verifying file...
|        file='/home/chris/dev/scarthgap/build/tmp/work/armv8a-poky-linux/onnxruntime/1.17.1/build/_deps/eigen-subbuild/eigen-populate-prefix/src/eigen-e7248b26a1ed53fa030c5c459f7ea095dfd276ac.zip'
| -- SHA1 hash of
|     /home/chris/dev/scarthgap/build/tmp/work/armv8a-poky-linux/onnxruntime/1.17.1/build/_deps/eigen-subbuild/eigen-populate-prefix/src/eigen-e7248b26a1ed53fa030c5c459f7ea095dfd276ac.zip
|   does not match expected value
|     expected: 'be8be39fdbc6e60e94fa7870b280707069b5b81a'
|       actual: '32b145f525a8308d7ab1c09388b2e288312d8eba'
| -- Hash mismatch, removing...
| -- Using src='https://gitlab.com/libeigen/eigen/-/archive/e7248b26a1ed53fa030c5c459f7ea095dfd276ac/eigen-e7248b26a1ed53fa030c5c459f7ea095dfd276ac.zip'
| -- verifying file...
|        file='/home/chris/dev/scarthgap/build/tmp/work/armv8a-poky-linux/onnxruntime/1.17.1/build/_deps/eigen-subbuild/eigen-populate-prefix/src/eigen-e7248b26a1ed53fa030c5c459f7ea095dfd276ac.zip'
| -- SHA1 hash of
|     /home/chris/dev/scarthgap/build/tmp/work/armv8a-poky-linux/onnxruntime/1.17.1/build/_deps/eigen-subbuild/eigen-populate-prefix/src/eigen-e7248b26a1ed53fa030c5c459f7ea095dfd276ac.zip
|   does not match expected value
|     expected: 'be8be39fdbc6e60e94fa7870b280707069b5b81a'
|       actual: '32b145f525a8308d7ab1c09388b2e288312d8eba'
| -- Hash mismatch, removing...
| -- Using src='https://gitlab.com/libeigen/eigen/-/archive/e7248b26a1ed53fa030c5c459f7ea095dfd276ac/eigen-e7248b26a1ed53fa030c5c459f7ea095dfd276ac.zip'
| -- verifying file...
|        file='/home/chris/dev/scarthgap/build/tmp/work/armv8a-poky-linux/onnxruntime/1.17.1/build/_deps/eigen-subbuild/eigen-populate-prefix/src/eigen-e7248b26a1ed53fa030c5c459f7ea095dfd276ac.zip'
| -- SHA1 hash of
|     /home/chris/dev/scarthgap/build/tmp/work/armv8a-poky-linux/onnxruntime/1.17.1/build/_deps/eigen-subbuild/eigen-populate-prefix/src/eigen-e7248b26a1ed53fa030c5c459f7ea095dfd276ac.zip
|   does not match expected value
|     expected: 'be8be39fdbc6e60e94fa7870b280707069b5b81a'
|       actual: '32b145f525a8308d7ab1c09388b2e288312d8eba'
| -- Hash mismatch, removing...
| CMake Error at eigen-subbuild/eigen-populate-prefix/src/eigen-populate-stamp/download-eigen-populate.cmake:170 (message):
|   Each download failed!
| 
| 
| 
| 
| 
| make[2]: *** [CMakeFiles/eigen-populate.dir/build.make:100: eigen-populate-prefix/src/eigen-populate-stamp/eigen-populate-download] Error 1
| make[1]: *** [CMakeFiles/Makefile2:83: CMakeFiles/eigen-populate.dir/all] Error 2
| make: *** [Makefile:91: all] Error 2
```


</p>
</details> 

The `onnxruntime` package pulls a specific zip archive for it's `eigen` dependency and checks the returned file against a known hash. It appears this file and its hash have changed, and the build no longer completes successfully. This seems to be related to this bug: https://gitlab.com/libeigen/eigen/-/issues/2744

This change is simply a workaround to update the expected hash to match the new one.

@simong01 @gibsson 