### PR TITLE
boundary-image-full: fix sdk build and generation by removing populate_sdk_qt6

### DIFF
--- a/dynamic-layers/qt6-layer/recipes-fsl/images/boundary-image-full.bb
+++ b/dynamic-layers/qt6-layer/recipes-fsl/images/boundary-image-full.bb
@@ -3,8 +3,6 @@
 
 require recipes-fsl/images/imx-image-multimedia.bb
 
-inherit populate_sdk_qt6
-
 CONFLICT_DISTRO_FEATURES = "directfb"
 
 IMAGE_INSTALL += " \


### PR DESCRIPTION
This PR and commit fixes the SDK build process and generation in our current Yocto Scarthgap release by removing `inherit populate_sdk_qt6` from _dynamic-layers/qt6-layer/recipes-fsl/images/_**[boundary-image-full.bb](https://github.com/boundarydevices/meta-boundary/blob/scarthgap/dynamic-layers/qt6-layer/recipes-fsl/images/boundary-image-full.bb)**. Tested and verified locally using the instructions provided at https://lairdcp.github.io/guides/yocto-scarthgap-release-for-imx-platforms/1.0/Yocto-Scarthgap-Release-for-i.MX-Platforms.html ... and ... https://lairdcp.github.io/guides/Boot2Qt-Scarthgap-Release-for-iMX-Platforms/1.0/Boot2Qt-Scarthgap-Release-for-i.MX-Platforms.html.